### PR TITLE
Added the forwarding of `formats` prop to `IntlProvider`

### DIFF
--- a/example/Label-story.js
+++ b/example/Label-story.js
@@ -39,6 +39,7 @@ storiesOf('Label', module)
     'es-ES': {
     }
   }, {
-    initialLocale: 'de-DE'
+    initialLocale: 'de-DE',
+    formats
   });
 

--- a/example/Label-story.js
+++ b/example/Label-story.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { storiesOf } from '@kadira/storybook';
+import Label from './Label';
+import { addLocaleData } from 'react-intl';
+import ru from 'react-intl/locale-data/ru';
+import es from 'react-intl/locale-data/es';
+import de from 'react-intl/locale-data/de';
+
+addLocaleData(ru);
+addLocaleData(es);
+addLocaleData(de);
+
+const formats = {
+  date: {
+    medium: {
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric'
+    }
+  }
+};
+
+storiesOf('Label', module)
+  .addWithIntl('Caption Localization', () => (<Label date={new Date()} />), {
+    'ru-RU': {
+    },
+    'de-DE': {
+    },
+    'es-ES': {
+    }
+  }, {
+    formats
+  })
+  .addWithIntl('Initial Locale (de-DE)', () => (<Label date={new Date()} />), {
+    'ru-RU': {
+    },
+    'de-DE': {
+    },
+    'es-ES': {
+    }
+  }, {
+    initialLocale: 'de-DE'
+  });
+

--- a/example/Label.js
+++ b/example/Label.js
@@ -1,0 +1,14 @@
+import React, { PropTypes } from 'react';
+import { FormattedDate } from 'react-intl';
+
+const Label = ({ date }) => (
+  <label>
+    <FormattedDate value={date} format="medium" />
+  </label>
+);
+
+Label.propTypes = {
+  date: PropTypes.instanceOf(Date).isRequired
+};
+
+export default Label;

--- a/src/components/Story/Story.js
+++ b/src/components/Story/Story.js
@@ -24,8 +24,8 @@ const styles = {
   }
 };
 
-const withIntl = (locale, messages, cmp) => (
-  <IntlProvider locale={locale} messages={messages}>
+const withIntl = (locale, messages, formats, cmp) => (
+  <IntlProvider locale={locale} messages={messages} formats={formats}>
     {cmp()}
   </IntlProvider>
 );
@@ -39,6 +39,7 @@ export default class Story extends Component {
   static propTypes = {
     render: PropTypes.func.isRequired,
     translations: PropTypes.object.isRequired,
+    formats: PropTypes.object,
     initialLocale: PropTypes.string
   };
 
@@ -82,7 +83,7 @@ export default class Story extends Component {
 
   render() {
     const { locale } = this.state;
-    const { translations, render } = this.props;
+    const { translations, formats, render } = this.props;
     const availableTranslations = this.getAvailableTranslations();
 
     const locales = [allLocales, ...availableTranslations];
@@ -94,13 +95,13 @@ export default class Story extends Component {
             .map(translation => (
               <div style={styles.item} key={translation}>
                 <span style={styles.label}>{translation}</span>
-                {withIntl(translation, translations[translation], render)}
+                {withIntl(translation, translations[translation], formats, render)}
               </div>)
             )
         );
       }
 
-      return () => withIntl(locale, translations[locale], render);
+      return () => withIntl(locale, translations[locale], formats, render);
     })();
 
     return (


### PR DESCRIPTION
Hi,

I have added the forwarding of the `formats` prop to the `IntlProvider` component.

This was necessary for being able to run components that use the `react-intl`'s `FormattedDate` component in Storybook.

I've added a sample story showcasing this.

Let me know if anything else is needed.

It would be great if this could be merged and published to `npm` so that I can continue using it without working with a copy.

Thanks,

Jeroen van de Neut